### PR TITLE
hima: remove qcmediaplayer

### DIFF
--- a/hima.mk
+++ b/hima.mk
@@ -197,13 +197,8 @@ PRODUCT_PACKAGES += \
     libOmxVdecHevc \
     libOmxVenc \
     libOmxVidcCommon \
-    libqcmediaplayer \
     libstagefrighthw \
-    libstagefright_soft_flacdec \
-    qcmediaplayer
-
-PRODUCT_BOOT_JARS += \
-    qcmediaplayer
+    libstagefright_soft_flacdec
 
 # Power
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
* Its not being built anyway and dex preopt fails because
  we're trying to add it to the bootclass path

Change-Id: Ieb192d1fc6c203adba217d5fb25d9529749d79d9